### PR TITLE
feat: Allow transport type and skip negotiation to be configured

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:signalr_chat_plugin/signalr_plugin.dart';
 import 'package:signalr_chat_plugin/user_room_connection.dart';
 import 'dart:developer' as developer;
+import 'package:signalr_core/signalr_core.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
@@ -35,7 +36,8 @@ class StartScreen extends StatelessWidget {
           onPressed: () {
             Navigator.of(context).push(
               MaterialPageRoute(
-                builder: (context) => const ChatScreen(room: "room 1", userName: "Vishnu"),
+                builder: (context) =>
+                    const ChatScreen(room: "room 1", userName: "Vishnu"),
               ),
             );
           },
@@ -93,7 +95,7 @@ class _ChatScreenState extends State<ChatScreen> {
       // Initialize SignalR with configuration
       await _chatPlugin.initSignalR(
         SignalRConnectionOptions(
-          serverUrl: 'https://your-signalR-endpoint',
+          serverUrl: 'https://wpr.intertoons.net/cloudsanadchatbot/chat',
           reconnectInterval: const Duration(seconds: 3),
           maxRetryAttempts: 5,
           autoReconnect: true,
@@ -101,6 +103,9 @@ class _ChatScreenState extends State<ChatScreen> {
             developer.log('SignalR error: $error');
             _handleError(error);
           },
+          transport:
+              HttpTransportType.webSockets, // Explicitly set transport type
+          skipNegotiation: false, // Explicitly set skipNegotiation
         ),
       );
 
@@ -110,7 +115,8 @@ class _ChatScreenState extends State<ChatScreen> {
       await Future.delayed(const Duration(milliseconds: 500));
 
       // Now join the room
-      developer.log('Attempting to join room: $_room with username: $_username');
+      developer
+          .log('Attempting to join room: $_room with username: $_username');
 
       await _chatPlugin.joinRoom(UserRoomConnection(
         user: _username,
@@ -134,7 +140,6 @@ class _ChatScreenState extends State<ChatScreen> {
           ),
         );
       }
-
     } catch (e, stackTrace) {
       developer.log('Error initializing chat: $e');
       developer.log('Stack trace: $stackTrace');
@@ -168,7 +173,7 @@ class _ChatScreenState extends State<ChatScreen> {
 
     // Listen to connected users
     _chatPlugin.connectedUsersStream.listen(
-          (users) {
+      (users) {
         developer.log('Connected users updated: $users');
         // Handle connected users if needed
       },
@@ -180,7 +185,7 @@ class _ChatScreenState extends State<ChatScreen> {
 
     // Listen to connection state changes
     _chatPlugin.connectionStateStream.listen(
-          (state) {
+      (state) {
         developer.log('Connection state changed to: $state');
         _handleConnectionState(state);
       },
@@ -192,7 +197,7 @@ class _ChatScreenState extends State<ChatScreen> {
 
     // Listen to errors
     _chatPlugin.errorStream.listen(
-          (error) {
+      (error) {
         developer.log('Error stream received: $error');
         _handleError(error);
       },
@@ -204,7 +209,8 @@ class _ChatScreenState extends State<ChatScreen> {
   }
 
   void _handleNewMessage(ChatMessage message) {
-    developer.log('Received message from ${message.sender}: ${message.content}');
+    developer
+        .log('Received message from ${message.sender}: ${message.content}');
 
     // Skip if we've already processed this message by ID
     if (message.messageId != null &&
@@ -225,10 +231,9 @@ class _ChatScreenState extends State<ChatScreen> {
         // that was sent within the last few seconds
         final now = DateTime.now();
         final existingMsgIndex = _messages.indexWhere((m) =>
-        m.sender == _username &&
+            m.sender == _username &&
             m.content == message.content &&
-            now.difference(m.timestamp).inSeconds < 5
-        );
+            now.difference(m.timestamp).inSeconds < 5);
 
         if (existingMsgIndex != -1) {
           // Update the existing message status
@@ -340,14 +345,14 @@ class _ChatScreenState extends State<ChatScreen> {
       // Send the message
       await _chatPlugin.sendMessage(message);
       developer.log('Message sent successfully');
-
     } catch (e, stackTrace) {
       developer.log('Error sending message: $e');
       developer.log('Stack trace: $stackTrace');
 
       // Update the message status to failed
       setState(() {
-        final index = _messages.indexWhere((m) => m.content == message && m.sender == _username);
+        final index = _messages
+            .indexWhere((m) => m.content == message && m.sender == _username);
         if (index != -1) {
           _messages[index] = ChatMessage(
             sender: _username,
@@ -448,7 +453,7 @@ class _ChatScreenState extends State<ChatScreen> {
         ),
         child: Column(
           crossAxisAlignment:
-          isMyMessage ? CrossAxisAlignment.end : CrossAxisAlignment.start,
+              isMyMessage ? CrossAxisAlignment.end : CrossAxisAlignment.start,
           children: [
             Text(
               message.sender,
@@ -535,20 +540,20 @@ class _ChatScreenState extends State<ChatScreen> {
           Expanded(
             child: _messages.isEmpty
                 ? Center(
-              child: Text(
-                _isInitialized
-                    ? 'No messages yet. Start a conversation!'
-                    : 'Connecting to chat...',
-                style: TextStyle(color: Colors.grey[600]),
-              ),
-            )
+                    child: Text(
+                      _isInitialized
+                          ? 'No messages yet. Start a conversation!'
+                          : 'Connecting to chat...',
+                      style: TextStyle(color: Colors.grey[600]),
+                    ),
+                  )
                 : ListView.builder(
-              controller: _scrollController,
-              reverse: true,
-              itemCount: _messages.length,
-              itemBuilder: (context, index) =>
-                  _buildMessageItem(_messages[index]),
-            ),
+                    controller: _scrollController,
+                    reverse: true,
+                    itemCount: _messages.length,
+                    itemBuilder: (context, index) =>
+                        _buildMessageItem(_messages[index]),
+                  ),
           ),
           Container(
             padding: const EdgeInsets.all(8.0),
@@ -567,7 +572,8 @@ class _ChatScreenState extends State<ChatScreen> {
                 Expanded(
                   child: TextField(
                     controller: _messageController,
-                    enabled: _isInitialized && _connectionState == ConnectionStatus.connected,
+                    enabled: _isInitialized &&
+                        _connectionState == ConnectionStatus.connected,
                     decoration: InputDecoration(
                       hintText: _isInitialized
                           ? 'Type a message...'
@@ -585,10 +591,12 @@ class _ChatScreenState extends State<ChatScreen> {
                 ),
                 const SizedBox(width: 8),
                 FloatingActionButton(
-                  onPressed: _isInitialized && _connectionState == ConnectionStatus.connected
+                  onPressed: _isInitialized &&
+                          _connectionState == ConnectionStatus.connected
                       ? _sendMessage
                       : null,
-                  backgroundColor: _isInitialized && _connectionState == ConnectionStatus.connected
+                  backgroundColor: _isInitialized &&
+                          _connectionState == ConnectionStatus.connected
                       ? Theme.of(context).primaryColor
                       : Colors.grey,
                   child: const Icon(Icons.send),

--- a/lib/connection_options.dart
+++ b/lib/connection_options.dart
@@ -1,3 +1,5 @@
+import 'package:signalr_core/signalr_core.dart';
+
 class SignalRConnectionOptions {
   final String serverUrl;
   final String? accessToken;
@@ -6,6 +8,8 @@ class SignalRConnectionOptions {
   final bool autoReconnect;
   final Function(String)? onError;
   final bool useSecureConnection;
+  final HttpTransportType transport;
+  final bool skipNegotiation;
 
   SignalRConnectionOptions({
     required this.serverUrl,
@@ -15,5 +19,7 @@ class SignalRConnectionOptions {
     this.autoReconnect = true,
     this.onError,
     this.useSecureConnection = true,
+    this.transport = HttpTransportType.webSockets,
+    this.skipNegotiation = false,
   });
 }

--- a/lib/signalr_chat_plugin.dart
+++ b/lib/signalr_chat_plugin.dart
@@ -15,22 +15,22 @@ class SignalRChatPlugin {
   final List<ChatMessage> _messageQueue = [];
 
   final StreamController<ChatMessage> _messageStreamController =
-  StreamController.broadcast();
+      StreamController.broadcast();
   final StreamController<List<String>> _connectedUsersStreamController =
-  StreamController.broadcast();
+      StreamController.broadcast();
 
   Stream<ChatMessage> get messagesStream => _messageStreamController.stream;
   Stream<List<String>> get connectedUsersStream =>
       _connectedUsersStreamController.stream;
 
   final StreamController<ConnectionStatus> _connectionStateController =
-  StreamController.broadcast();
+      StreamController.broadcast();
 
   Stream<ConnectionStatus> get connectionStateStream =>
       _connectionStateController.stream;
 
   final StreamController<String> _errorStreamController =
-  StreamController.broadcast();
+      StreamController.broadcast();
 
   Stream<String> get errorStream => _errorStreamController.stream;
 
@@ -108,22 +108,24 @@ class SignalRChatPlugin {
 
       developer.log('Building SignalR connection to: ${options.serverUrl}');
 
-      _connection = HubConnectionBuilder()
-          .withUrl(
-        options.serverUrl,
-        HttpConnectionOptions(
-          transport: HttpTransportType.longPolling,
-          skipNegotiation: false,
-          accessTokenFactory:
-          options.accessToken != null
-              ? () async => options.accessToken!
-              : null,
-          logging: (level, message) =>
-              developer.log('SignalR: [$level] $message'),
-        ),
-      )
-          .withAutomaticReconnect([0, 2000, 5000, 10000, 30000])
-          .build();
+      _connection =
+          HubConnectionBuilder()
+              .withUrl(
+                options.serverUrl,
+                HttpConnectionOptions(
+                  transport: options.transport,
+                  skipNegotiation: options.skipNegotiation,
+                  accessTokenFactory:
+                      options.accessToken != null
+                          ? () async => options.accessToken!
+                          : null,
+                  logging:
+                      (level, message) =>
+                          developer.log('SignalR: [$level] $message'),
+                ),
+              )
+              .withAutomaticReconnect([0, 2000, 5000, 10000, 30000])
+              .build();
 
       // Setup handlers before starting connection
       _setupConnectionHandlers();
@@ -179,7 +181,8 @@ class SignalRChatPlugin {
         try {
           final sender = arguments[0]?.toString() ?? 'Unknown';
           final content = arguments[1]?.toString() ?? '';
-          final timestamp = arguments[2]?.toString() ?? DateTime.now().toIso8601String();
+          final timestamp =
+              arguments[2]?.toString() ?? DateTime.now().toIso8601String();
 
           final message = ChatMessage(
             sender: sender,
@@ -204,9 +207,10 @@ class SignalRChatPlugin {
 
       if (arguments != null && arguments.isNotEmpty) {
         try {
-          final users = (arguments[0] as List<dynamic>)
-              .map((user) => user.toString())
-              .toList();
+          final users =
+              (arguments[0] as List<dynamic>)
+                  .map((user) => user.toString())
+                  .toList();
           developer.log('Connected users: $users');
           _connectedUsersStreamController.add(users);
         } catch (e) {
@@ -239,13 +243,12 @@ class SignalRChatPlugin {
     _currentConnection = userConnection;
 
     try {
-      developer.log('Joining room - User: ${userConnection.user}, Room: ${userConnection.room}');
+      developer.log(
+        'Joining room - User: ${userConnection.user}, Room: ${userConnection.room}',
+      );
 
       // Try different invoke patterns based on what your server expects
-      await _connection.invoke(
-        'JoinRoom',
-        args: [userConnection.toJson()],
-      );
+      await _connection.invoke('JoinRoom', args: [userConnection.toJson()]);
 
       developer.log('JoinRoom invoked successfully');
     } catch (e) {
@@ -269,7 +272,9 @@ class SignalRChatPlugin {
 
   Future<void> sendMessage(String content) async {
     if (_connection.state != HubConnectionState.connected) {
-      developer.log('Cannot send message: Not connected (state: ${_connection.state})');
+      developer.log(
+        'Cannot send message: Not connected (state: ${_connection.state})',
+      );
 
       _messageQueue.add(
         ChatMessage(


### PR DESCRIPTION
This commit introduces the ability to configure the transport type and skip negotiation settings for the SignalR connection.

The `SignalRConnectionOptions` class now includes `transport` and `skipNegotiation` properties. The `transport` property defaults to `HttpTransportType.webSockets` and `skipNegotiation` defaults to `false`.

The example app has been updated to use `HttpTransportType.webSockets` and set `skipNegotiation` to `false` for the SignalR connection, and the server URL has been updated.