### PR TITLE
Improve SignalR reconnection logic and add connectivity check

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -37,7 +37,7 @@ class StartScreen extends StatelessWidget {
             Navigator.of(context).push(
               MaterialPageRoute(
                 builder: (context) =>
-                    const ChatScreen(room: "room 1", userName: "Vishnu"),
+                    const ChatScreen(room: "UUUUU", userName: "Vishnu"),
               ),
             );
           },
@@ -105,7 +105,7 @@ class _ChatScreenState extends State<ChatScreen> {
           },
           transport:
               HttpTransportType.webSockets, // Explicitly set transport type
-          skipNegotiation: false, // Explicitly set skipNegotiation
+          skipNegotiation: true, // Explicitly set skipNegotiation
         ),
       );
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ environment:
   flutter: ">=1.20.0"
 
 dependencies:
+  connectivity_plus: ^6.1.4
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.1.8


### PR DESCRIPTION
Enhanced the SignalRChatPlugin to check for network connectivity before attempting reconnection, handle invalid ':0' ports in URLs, and add better logging and error handling for DNS errors. Updated the reconnection flow to rejoin the room after reconnecting. Added 'connectivity_plus' as a dependency in pubspec.yaml. Also updated example to use a different room and set skipNegotiation to true.